### PR TITLE
Issue 120

### DIFF
--- a/D4e/d4e_functions.py
+++ b/D4e/d4e_functions.py
@@ -354,7 +354,7 @@ class D4eConditionButton(discord.ui.Button):
                     guild=self.guild
                 )
                 await interaction.edit_original_response(content=output_string)
-                await initiative.block_update_init(
+                await initiative.update_pinned_tracker(
                     self.ctx, interaction.message.id, self.engine, self.bot, guild=self.guild
                 )
             except Exception:

--- a/D4e/d4e_functions.py
+++ b/D4e/d4e_functions.py
@@ -355,7 +355,7 @@ class D4eConditionButton(discord.ui.Button):
                 )
                 await interaction.edit_original_response(content=output_string)
                 await initiative.update_pinned_tracker(
-                    self.ctx, interaction.message.id, self.engine, self.bot, guild=self.guild
+                    self.ctx, self.engine, self.bot, guild=self.guild
                 )
             except Exception:
                 output_string = "Unable to process save, perhaps the condition was removed."

--- a/initiative.py
+++ b/initiative.py
@@ -1474,63 +1474,63 @@ async def generic_block_get_tracker(
         await report.report()
 
 
-# Gets the locations of the pinned trackers, then updates them with the newest tracker
-async def update_pinned_tracker(ctx: discord.ApplicationContext, engine, bot, guild=None):
-    logging.info("update_pinned_tracker")
-    guild = await get_guild(ctx, guild, refresh=True)  # get the guild
-    logging.info(f"UPT1: Guild: {guild.id}")
-
-    # Get the tracker messages
-    tracker = guild.tracker
-    tracker_channel = guild.tracker_channel
-    gm_tracker = guild.gm_tracker
-    gm_tracker_channel = guild.gm_tracker_channel
-
-    # Fix the Tracker if needed
-    await init_integrity(ctx, engine, guild=guild)
-
-    try:
-        # Re-acquire the tracker after the fix
-        guild = await get_guild(ctx, guild, refresh=True)
-        logging.info(f"saved_order: {guild.saved_order}")
-        logging.info(f"init_pos: {guild.initiative}")
-
-        # If in initiative, update the active tracker
-        if guild.last_tracker is not None:
-            await block_update_init(ctx, guild.last_tracker, engine, bot, guild=guild)
-
-        # Update the Pinned tracker
-        # if tracker is not None:
-        #     tracker_display_string = await block_get_tracker(
-        #         await get_init_list(ctx, engine, guild=guild), guild.initiative, ctx, engine, bot, guild=guild
-        #     )
-        #     channel = bot.get_channel(tracker_channel)
-        #     message = await channel.fetch_message(tracker)
-        #     await message.edit(tracker_display_string)
-        #     logging.info("UPT2: tracker updated")
-        #
-        # # Update the GM tracker
-        # if gm_tracker is not None:
-        #     gm_tracker_display_string = await block_get_tracker(
-        #         await get_init_list(ctx, engine, guild=guild),
-        #         guild.initiative,
-        #         ctx,
-        #         engine,
-        #         bot,
-        #         gm=True,
-        #         guild=guild,
-        #     )
-        #     gm_channel = bot.get_channel(gm_tracker_channel)
-        #     gm_message = await gm_channel.fetch_message(gm_tracker)
-        #     await gm_message.edit(gm_tracker_display_string)
-        #     logging.info("UPT3: gm tracker updated")
-    except NoResultFound:
-        if ctx is not None:
-            await ctx.channel.send(error_not_initialized, delete_after=30)
-    except Exception as e:
-        logging.error(f"update_pinned_tracker: {e}")
-        report = ErrorReport(ctx, update_pinned_tracker.__name__, e, bot)
-        await report.report()
+# # Gets the locations of the pinned trackers, then updates them with the newest tracker
+# async def update_pinned_tracker(ctx: discord.ApplicationContext, engine, bot, guild=None):
+#     logging.info("update_pinned_tracker")
+#     guild = await get_guild(ctx, guild, refresh=True)  # get the guild
+#     logging.info(f"UPT1: Guild: {guild.id}")
+#
+#     # Get the tracker messages
+#     tracker = guild.tracker
+#     tracker_channel = guild.tracker_channel
+#     gm_tracker = guild.gm_tracker
+#     gm_tracker_channel = guild.gm_tracker_channel
+#
+#     # Fix the Tracker if needed
+#     await init_integrity(ctx, engine, guild=guild)
+#
+#     try:
+#         # Re-acquire the tracker after the fix
+#         guild = await get_guild(ctx, guild, refresh=True)
+#         logging.info(f"saved_order: {guild.saved_order}")
+#         logging.info(f"init_pos: {guild.initiative}")
+#
+#         # If in initiative, update the active tracker
+#         if guild.last_tracker is not None:
+#             await update_pinned_tracker(ctx, guild.last_tracker, engine, bot, guild=guild)
+#         else:
+#             # Update the Pinned tracker
+#             if tracker is not None:
+#                 tracker_display_string = await block_get_tracker(
+#                     await get_init_list(ctx, engine, guild=guild), guild.initiative, ctx, engine, bot, guild=guild
+#                 )
+#                 channel = bot.get_channel(tracker_channel)
+#                 message = await channel.fetch_message(tracker)
+#                 await message.edit(tracker_display_string)
+#                 logging.info("UPT2: tracker updated")
+#
+#             # Update the GM tracker
+#             if gm_tracker is not None:
+#                 gm_tracker_display_string = await block_get_tracker(
+#                     await get_init_list(ctx, engine, guild=guild),
+#                     guild.initiative,
+#                     ctx,
+#                     engine,
+#                     bot,
+#                     gm=True,
+#                     guild=guild,
+#                 )
+#                 gm_channel = bot.get_channel(gm_tracker_channel)
+#                 gm_message = await gm_channel.fetch_message(gm_tracker)
+#                 await gm_message.edit(gm_tracker_display_string)
+#                 logging.info("UPT3: gm tracker updated")
+#     except NoResultFound:
+#         if ctx is not None:
+#             await ctx.channel.send(error_not_initialized, delete_after=30)
+#     except Exception as e:
+#         logging.error(f"update_pinned_tracker: {e}")
+#         report = ErrorReport(ctx, update_pinned_tracker.__name__, e, bot)
+#         await report.report()
 
 
 # Post a new initiative tracker and updates the pinned trackers
@@ -1661,7 +1661,7 @@ async def block_post_init(ctx: discord.ApplicationContext, engine, bot: discord.
 
 
 # Updates the active initiative tracker (not the pinned tracker)
-async def block_update_init(ctx: discord.ApplicationContext, edit_id, engine, bot: discord.Bot, guild=None):
+async def update_pinned_tracker(ctx: discord.ApplicationContext, engine, bot: discord.Bot, guild=None):
     logging.info(f"block_update_init")
 
     # Query the initiative position for the tracker and post it
@@ -1715,22 +1715,24 @@ async def block_update_init(ctx: discord.ApplicationContext, edit_id, engine, bo
                 view.add_item(new_button)
             view.add_item(ui_components.InitRefreshButton(ctx, bot, guild=guild))
             view.add_item((ui_components.NextButton(bot, guild=guild)))
-            tracker_channel = bot.get_channel(guild.tracker_channel)
-            edit_message = await tracker_channel.fetch_message(edit_id)
-            await edit_message.edit(
-                content=f"{tracker_string}\n{ping_string}",
-                view=view,
-            )
+            if guild.last_tracker is not None:
+                tracker_channel = bot.get_channel(guild.tracker_channel)
+                edit_message = await tracker_channel.fetch_message(guild.last_tracker)
+                await edit_message.edit(
+                    content=f"{tracker_string}\n{ping_string}",
+                    view=view,
+                )
 
         else:
             view.add_item(ui_components.InitRefreshButton(ctx, bot, guild=guild))
             view.add_item((ui_components.NextButton(bot, guild=guild)))
-            tracker_channel = bot.get_channel(guild.tracker_channel)
-            edit_message = await tracker_channel.fetch_message(edit_id)
-            await edit_message.edit(
-                content=f"{tracker_string}\n{ping_string}",
-                view=view,
-            )
+            if guild.last_tracker is not None:
+                tracker_channel = bot.get_channel(guild.tracker_channel)
+                edit_message = await tracker_channel.fetch_message(guild.last_tracker)
+                await edit_message.edit(
+                    content=f"{tracker_string}\n{ping_string}",
+                    view=view,
+                )
         if guild.tracker is not None:
             try:
                 channel = bot.get_channel(guild.tracker_channel)
@@ -1760,7 +1762,7 @@ async def block_update_init(ctx: discord.ApplicationContext, edit_id, engine, bo
         await ctx.channel.send(error_not_initialized, delete_after=30)
     except Exception as e:
         logging.error(f"block_update_init: {e}")
-        report = ErrorReport(ctx, block_update_init.__name__, e, bot)
+        report = ErrorReport(ctx, update_pinned_tracker.__name__, e, bot)
         await report.report()
 
 

--- a/initiative.py
+++ b/initiative.py
@@ -1699,23 +1699,23 @@ async def update_pinned_tracker(ctx: discord.ApplicationContext, engine, bot: di
             ping_string = ""
         view = discord.ui.View(timeout=None)
         # Check for systems:
-        if guild.system == "D4e":
-            logging.info("BPI3: d4e")
+        if guild.last_tracker is not None:
+            if guild.system == "D4e":
+                logging.info("BPI3: d4e")
 
-            async with async_session() as session:
-                result = await session.execute(select(Tracker).where(Tracker.name == init_list[guild.initiative].name))
-                char = result.scalars().one()
-            async with async_session() as session:
-                result = await session.execute(
-                    select(Condition).where(Condition.character_id == char.id).where(Condition.flex == true())
-                )
-                conditions = result.scalars().all()
-            for con in conditions:
-                new_button = D4e.d4e_functions.D4eConditionButton(con, ctx, bot, char, guild=guild)
-                view.add_item(new_button)
-            view.add_item(ui_components.InitRefreshButton(ctx, bot, guild=guild))
-            view.add_item((ui_components.NextButton(bot, guild=guild)))
-            if guild.last_tracker is not None:
+                async with async_session() as session:
+                    result = await session.execute(select(Tracker).where(Tracker.name == init_list[guild.initiative].name))
+                    char = result.scalars().one()
+                async with async_session() as session:
+                    result = await session.execute(
+                        select(Condition).where(Condition.character_id == char.id).where(Condition.flex == true())
+                    )
+                    conditions = result.scalars().all()
+                for con in conditions:
+                    new_button = D4e.d4e_functions.D4eConditionButton(con, ctx, bot, char, guild=guild)
+                    view.add_item(new_button)
+                view.add_item(ui_components.InitRefreshButton(ctx, bot, guild=guild))
+                view.add_item((ui_components.NextButton(bot, guild=guild)))
                 tracker_channel = bot.get_channel(guild.tracker_channel)
                 edit_message = await tracker_channel.fetch_message(guild.last_tracker)
                 await edit_message.edit(
@@ -1723,16 +1723,16 @@ async def update_pinned_tracker(ctx: discord.ApplicationContext, engine, bot: di
                     view=view,
                 )
 
-        else:
-            view.add_item(ui_components.InitRefreshButton(ctx, bot, guild=guild))
-            view.add_item((ui_components.NextButton(bot, guild=guild)))
-            if guild.last_tracker is not None:
-                tracker_channel = bot.get_channel(guild.tracker_channel)
-                edit_message = await tracker_channel.fetch_message(guild.last_tracker)
-                await edit_message.edit(
-                    content=f"{tracker_string}\n{ping_string}",
-                    view=view,
-                )
+            else:
+                view.add_item(ui_components.InitRefreshButton(ctx, bot, guild=guild))
+                view.add_item((ui_components.NextButton(bot, guild=guild)))
+                if guild.last_tracker is not None:
+                    tracker_channel = bot.get_channel(guild.tracker_channel)
+                    edit_message = await tracker_channel.fetch_message(guild.last_tracker)
+                    await edit_message.edit(
+                        content=f"{tracker_string}\n{ping_string}",
+                        view=view,
+                    )
         if guild.tracker is not None:
             try:
                 channel = bot.get_channel(guild.tracker_channel)

--- a/ui_components.py
+++ b/ui_components.py
@@ -64,9 +64,8 @@ class InitRefreshButton(discord.ui.Button):
         try:
             await interaction.response.send_message("Refreshed", ephemeral=True)
             print(interaction.message.id)
-            await initiative.block_update_init(
+            await initiative.update_pinned_tracker(
                 self.ctx,
-                interaction.message.id,
                 self.engine,
                 self.bot,
                 guild=self.guild,


### PR DESCRIPTION
Trackers were not updating if the channel wasn't in combat.  This was due to me getting rid of most of the functions of update_pinned_tracker, and just having the function call block_update_init.  Except update_pinned_tracker was only calling block_update_init if combat was occuring.  Initially, I just had an else statement involved to update the trackers even out of combat, but I realized most of the code was duplicate, so I combined to two functions together and then edited the only two places where block_update_init was being called by itself.

Shouldn't change functionality, but it does save a function call and a database call potentially.