### PR TITLE
Hazards and NPC Importer Improvements

### DIFF
--- a/Base/Character.py
+++ b/Base/Character.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import sessionmaker
 
+import Bot
 import time_keeping_functions
 from database_models import get_tracker, get_condition
 from error_handling_reporting import error_not_initialized
@@ -496,6 +497,8 @@ class Character:
         :return: No returned value
         """
         logging.info("Clean CC")
+        if bot is None:
+            bot = Bot.bot
         current_time = await get_time(self.ctx, self.engine, guild=self.guild)
         async_session = sessionmaker(self.engine, expire_on_commit=False, class_=AsyncSession)
         Condition = await get_condition(self.ctx, self.engine, self.guild.id)
@@ -520,6 +523,8 @@ class Character:
                     await tracker_channel.send(f"{row.title} removed from {self.char_name}")
 
     async def get_char_sheet(self, bot):
+        if bot is None:
+            bot = Bot.bot
         try:
             if self.character_model.player:
                 status = "PC:"

--- a/Base/Character.py
+++ b/Base/Character.py
@@ -303,6 +303,11 @@ class Character:
             return f"Failed to set initiative: {e}"
 
     async def update(self):
+        """
+        Updates the character model by requerying the database and replacing the properities with updated values.  Needs
+        to be called after each update to the database entry.
+        :return: No return value
+        """
         logging.info(f"Updating character: {self.char_name}")
         self.character_model = await self.character()
         self.char_name = self.character_model.name

--- a/Base/Character.py
+++ b/Base/Character.py
@@ -148,6 +148,15 @@ class Character:
             await session.commit()
             await self.update()
 
+    async def roll_initiative(self):
+        """
+        Rolls the initiative string and sets it in the database.
+        :return: integer (Initiative Value)
+        """
+        init = d20.roll(self.init_string).total
+        await self.set_init(init)
+        return init
+
     async def change_hp(self, amount: int, heal: bool, post=True):
         """
         Changes the health value by the set amount and writes it to the database.
@@ -225,17 +234,20 @@ class Character:
         :return: String with the interpreted health value.
         """
         logging.info("Calculate hp")
-        hp = self.current_hp / self.max_hp
-        if hp == 1:
-            hp_string = "Uninjured"
-        elif hp > 0.5:
-            hp_string = "Injured"
-        elif hp >= 0.1:
-            hp_string = "Bloodied"
-        elif hp > 0:
-            hp_string = "Critical"
-        else:
-            hp_string = "Dead"
+        try:
+            hp = self.current_hp / self.max_hp
+            if hp == 1:
+                hp_string = "Uninjured"
+            elif hp > 0.5:
+                hp_string = "Injured"
+            elif hp >= 0.1:
+                hp_string = "Bloodied"
+            elif hp > 0:
+                hp_string = "Critical"
+            else:
+                hp_string = "Dead"
+        except Exception:
+            hp_string = ""
 
         return hp_string
 

--- a/Base/Character.py
+++ b/Base/Character.py
@@ -332,6 +332,19 @@ class Character:
         data: str = "",
         target: str = None,
     ):
+        """
+        Writes a condition to the condition database attached to the character's ID.
+        :param title: string - Condition Name
+        :param counter: boolean
+        :param number: integer
+        :param unit: string "Minute", "Hour", or "Days"
+        :param auto_decrement: boolean
+        :param flex: boolean - Usage varies depending on the system. In the base system it is used for determining if a
+        condition will decrement at the beginning or end of the turn.
+        :param data: string - used fors scripting in certain systems
+        :param target: string - Default None . Name of a character to decrement on their turn
+        :return: boolean - True for success, False for failure.
+        """
         logging.info("set_cc")
         # Get the Character's data
 
@@ -339,7 +352,6 @@ class Character:
         Condition = await get_condition(self.ctx, self.engine, id=self.guild.id)
 
         if target is None:
-            target = self.char_name
             target_id = self.character_model.id
         else:
             Tracker = await get_tracker(self.ctx, self.engine, id=self.guild.id)
@@ -372,7 +384,6 @@ class Character:
                     )
                     session.add(condition)
                 await session.commit()
-                # await update_pinned_tracker(ctx, engine, bot)
                 return True
 
             else:  # If its time based, then calculate the end time, before writing it
@@ -398,7 +409,6 @@ class Character:
                     )
                     session.add(condition)
                 await session.commit()
-                # await update_pinned_tracker(ctx, engine, bot)
                 return True
 
         except NoResultFound:
@@ -410,6 +420,11 @@ class Character:
 
     # Delete CC
     async def delete_cc(self, condition):
+        """
+        Deletes a condition associated with the character
+        :param condition: string - Conditin name
+        :return: boolean - True for success, False for failure
+        """
         logging.info("delete_Cc")
         Condition = await get_condition(self.ctx, self.engine, id=self.guild.id)
         async_session = sessionmaker(self.engine, expire_on_commit=False, class_=AsyncSession)
@@ -439,6 +454,12 @@ class Character:
             return False
 
     async def edit_cc(self, condition: str, value: int):
+        """
+        Edits the value of a condition associated with the character
+        :param condition: string - Condition name
+        :param value: integer - Value to set
+        :return: boolean - True for success, False for failure
+        """
         logging.info("edit_cc")
 
         Condition = await get_condition(self.ctx, self.engine, id=self.guild.id)
@@ -468,6 +489,12 @@ class Character:
             return False
 
     async def check_time_cc(self, bot=None):
+        """
+        Checks each time based condition associated with the character and checks to see if the time has expired. If it
+        has, it cleanly deletes it.  Used during initiative.
+        :param bot: Default= None. If present, this can be used outside of a tracked channel.
+        :return: No returned value
+        """
         logging.info("Clean CC")
         current_time = await get_time(self.ctx, self.engine, guild=self.guild)
         async_session = sessionmaker(self.engine, expire_on_commit=False, class_=AsyncSession)

--- a/Base/Tracker.py
+++ b/Base/Tracker.py
@@ -442,7 +442,7 @@ class Tracker:
                             # Advance time time by the number of seconds in the guild.time column. Default is 6
                             # seconds ala D&D standard
                             await advance_time(self.ctx, self.engine, None, second=self.guild.time, guild=self.guild)
-                            await current_character.check_time_cc(self.bot)
+                            await current_character.check_time_cc()
                             logging.info("BAI8: cc checked")
 
                 # Decrement the conditions
@@ -587,7 +587,7 @@ class Tracker:
                             tracker_channel = self.bot.get_channel(self.guild.tracker_channel)
                             await tracker_channel.send(embed=del_embed)
                 else:
-                    await Con_Character.check_time_cc(bot=self.bot)
+                    await Con_Character.check_time_cc()
 
         except Exception as e:
             logging.error(f"block_advance_initiative: {e}")

--- a/Base/Tracker.py
+++ b/Base/Tracker.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 from datetime import datetime
 
-import d20
 import discord
 from sqlalchemy import select, true, or_, false
 from sqlalchemy.exc import NoResultFound
@@ -394,8 +393,8 @@ class Tracker:
                         if model.init == 0:
                             await asyncio.sleep(0)
                             try:
-                                roll = d20.roll(char.init_string)
-                                await model.set_init(roll)
+                                # roll = d20.roll(char.init_string)
+                                await model.roll_initiative()
                             except Exception:
                                 await model.set_init(0)
                 else:

--- a/Bot.py
+++ b/Bot.py
@@ -1,0 +1,11 @@
+import discord
+
+intents = discord.Intents.default()
+intents.members = True
+# intents.messages = True
+# intents = discord.Intents.all()
+bot = discord.Bot(
+    intents=intents,
+    allowed_mention=discord.AllowedMentions.all()
+    # debug_guilds=[GUILD]
+)

--- a/D4e/D4e_Character.py
+++ b/D4e/D4e_Character.py
@@ -283,7 +283,7 @@ class D4eEditCharacterModal(discord.ui.Modal):
         # Tracker_Model = await get_tracker_model(self.ctx, self.bot, guild=guild, engine=self.engine)
         # await Tracker_Model.update_pinned_tracker()
         # print('Tracker Updated')
-        await self.ctx.channel.send(embeds=await Character_Model.get_char_sheet(self.bot))
+        await self.ctx.channel.send(embeds=await Character_Model.get_char_sheet(bot=self.bot))
         return True
 
     async def on_error(self, error: Exception, interaction: Interaction) -> None:

--- a/EPF/EPF_NPC_Importer.py
+++ b/EPF/EPF_NPC_Importer.py
@@ -79,7 +79,8 @@ async def epf_npc_lookup(
     async with async_session() as session:
         result = await session.execute(select(EPF_NPC).where(EPF_NPC.name == lookup))
         data = result.scalars().one()
-    # await lookup_engine.dispose()
+
+    print(data.resistance)
 
     # elite/weak adjustments
     hp_mod = 0
@@ -243,12 +244,13 @@ async def write_resitances(
         await delete_intested_items(Character_Model.char_name, ctx, guild, engine)
 
     # Then write the new ones
+    # print(resistance)
     try:
         async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
         async with async_session() as session:
             for key, value in resistance["resist"].items():
-                print(key)
-                print(type(value))
+                # print(key)
+                # print(type(value))
                 if type(value) == dict:
                     exceptions = ""
                     for item in value["exceptions"]:
@@ -262,7 +264,7 @@ async def write_resitances(
                         key, True, value, "Round", False, data=condition_string, visible=False, update=False
                     )
             for key, value in resistance["weak"].items():
-                print(key)
+                # print(key)
                 if type(value) == dict:
                     exceptions = ""
                     for item in value["exceptions"]:
@@ -276,7 +278,7 @@ async def write_resitances(
                         key, True, value, "Round", False, data=condition_string, visible=False, update=False
                     )
             for key in resistance["immune"].keys():
-                print(key)
+                # print(key)
                 if type(value) == dict:
                     exceptions = ""
                     for item in value["exceptions"]:
@@ -288,6 +290,21 @@ async def write_resitances(
                     await Character_Model.set_cc(
                         key, True, 1, "Round", False, data=condition_string, visible=False, update=False
                     )
+            if "other" in resistance.keys():
+                # print("other")
+                if "init-skill" in resistance["other"].keys():
+                    # print("init-skill")
+                    await Character_Model.set_cc(
+                        "init-skill",
+                        True,
+                        1,
+                        "Round",
+                        False,
+                        data=f"init-skill {resistance['other']['init-skill']}",
+                        visible=False,
+                        update=False,
+                    )
+
         return True
     except Exception:
         return False

--- a/EPF/EPF_Tracker.py
+++ b/EPF/EPF_Tracker.py
@@ -107,7 +107,7 @@ class EPF_Tracker(Tracker):
                     # Advance time time by the number of seconds in the guild.time column. Default is 6
                     # seconds ala D&D standard
                     await advance_time(self.ctx, self.engine, self.bot, second=self.guild.time, guild=self.guild)
-                    await current_character.check_time_cc(self.bot)
+                    await current_character.check_time_cc()
                     logging.info("BAI8: cc checked")
 
             current_character = await get_character(

--- a/EPF/EPF_Tracker.py
+++ b/EPF/EPF_Tracker.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 from datetime import datetime
 
-import d20
 import discord
 from sqlalchemy import select, or_
 from sqlalchemy.exc import NoResultFound
@@ -62,8 +61,7 @@ class EPF_Tracker(Tracker):
                             await asyncio.sleep(0)
                             model = await get_character(char.name, self.ctx, guild=self.guild, engine=self.engine)
                             try:
-                                roll = d20.roll(char.init_string)
-                                await model.set_init(roll)
+                                await model.roll_initiative()
                             except ValueError:
                                 model.set_init(0)
             else:

--- a/PF2e/PF2_Character.py
+++ b/PF2e/PF2_Character.py
@@ -174,7 +174,7 @@ class PF2EditCharacterModal(discord.ui.Modal):
 
         # Tracker_Model = await get_tracker_model(self.ctx, self.bot, guild=guild, engine=self.engine)
         # await Tracker_Model.update_pinned_tracker()
-        await self.ctx.channel.send(embeds=await self.character.get_char_sheet(self.bot))
+        await self.ctx.channel.send(embeds=await self.character.get_char_sheet(bot=self.bot))
         return True
 
     async def on_error(self, error: Exception, interaction: Interaction) -> None:

--- a/RED/RED_Tracker.py
+++ b/RED/RED_Tracker.py
@@ -169,7 +169,7 @@ class RED_Tracker(Tracker):
                             # Advance time time by the number of seconds in the guild.time column. Default is 6
                             # seconds ala D&D standard
                             await advance_time(self.ctx, self.engine, None, second=self.guild.time, guild=self.guild)
-                            await current_character.check_time_cc(self.bot)
+                            await current_character.check_time_cc()
                             logging.info("BAI8: cc checked")
 
                 # Decrement the conditions

--- a/initiative.py
+++ b/initiative.py
@@ -285,7 +285,7 @@ class InitiativeCog(commands.Cog):
         if await auto_complete.hard_lock(ctx, name):
             try:
                 Character_Model = await get_character(name, ctx, engine=engine)
-                embed = await Character_Model.get_char_sheet(self.bot)
+                embed = await Character_Model.get_char_sheet(bot=self.bot)
                 await ctx.send_followup(embeds=embed)
             except Exception as e:
                 logging.warning(f"char sheet {e}")

--- a/main.py
+++ b/main.py
@@ -7,10 +7,10 @@ import logging
 # imports
 import os
 import sys
+from Bot import bot
 
 # import tracemalloc
 
-import discord
 from dotenv import load_dotenv
 
 # Set up logging
@@ -43,15 +43,15 @@ DATABASE = os.getenv("DATABASE")
 # tracemalloc.start()
 
 # set up the bot/intents
-intents = discord.Intents.default()
-intents.members = True
-# intents.messages = True
-# intents = discord.Intents.all()
-bot = discord.Bot(
-    intents=intents,
-    allowed_mention=discord.AllowedMentions.all()
-    # debug_guilds=[GUILD]
-)
+# intents = discord.Intents.default()
+# intents.members = True
+# # intents.messages = True
+# # intents = discord.Intents.all()
+# bot = discord.Bot(
+#     intents=intents,
+#     allowed_mention=discord.AllowedMentions.all()
+#     # debug_guilds=[GUILD]
+# )
 
 
 # Print Status on Connected - Outputs to server log

--- a/utils/Char_Getter.py
+++ b/utils/Char_Getter.py
@@ -18,6 +18,16 @@ from utils.utils import get_guild
 
 
 async def get_character(char_name, ctx, guild=None, engine=None):
+    """
+    Function to asynchronously query the database and then populate a character model. Intelligently supplies the proper
+    model depending on the system.
+
+    :param char_name: string
+    :param ctx:
+    :param guild:
+    :param engine:
+    :return: Character model of the appropriate subclass
+    """
     logging.info("get_character")
     if engine is None:
         engine = get_asyncio_db_engine(user=USERNAME, password=PASSWORD, host=HOSTNAME, port=PORT, db=SERVER_DATA)

--- a/utils/Tracker_Getter.py
+++ b/utils/Tracker_Getter.py
@@ -24,7 +24,8 @@ async def get_tracker_model(ctx, bot, guild=None, engine=None):
     :param engine:
     :return: Tracker Model of the appropriate type
     """
-    bot = Bot.bot
+    if bot is None:
+        bot = Bot.bot
     if engine is None:
         engine = get_asyncio_db_engine(user=USERNAME, password=PASSWORD, host=HOSTNAME, port=PORT, db=SERVER_DATA)
     guild = await get_guild(ctx, guild)

--- a/utils/Tracker_Getter.py
+++ b/utils/Tracker_Getter.py
@@ -2,6 +2,7 @@ import logging
 
 import discord
 
+import Bot
 from RED.RED_Tracker import get_RED_Tracker
 from database_operations import USERNAME, PASSWORD, HOSTNAME, PORT, SERVER_DATA
 from Base.Tracker import get_init_list, Tracker
@@ -23,6 +24,7 @@ async def get_tracker_model(ctx, bot, guild=None, engine=None):
     :param engine:
     :return: Tracker Model of the appropriate type
     """
+    bot = Bot.bot
     if engine is None:
         engine = get_asyncio_db_engine(user=USERNAME, password=PASSWORD, host=HOSTNAME, port=PORT, db=SERVER_DATA)
     guild = await get_guild(ctx, guild)

--- a/utils/Tracker_Getter.py
+++ b/utils/Tracker_Getter.py
@@ -14,6 +14,15 @@ from STF.STF_Tracker import get_STF_Tracker
 
 
 async def get_tracker_model(ctx, bot, guild=None, engine=None):
+    """
+    Function to asychronously query the database and then populate the tracker model intelligently
+    with the appropriate model.
+    :param ctx:
+    :param bot:
+    :param guild:
+    :param engine:
+    :return: Tracker Model of the appropriate type
+    """
     if engine is None:
         engine = get_asyncio_db_engine(user=USERNAME, password=PASSWORD, host=HOSTNAME, port=PORT, db=SERVER_DATA)
     guild = await get_guild(ctx, guild)


### PR DESCRIPTION
EPF:
 - NPC Importer now supports importing of hazards and complex hazards from the database
 - NPC Importer now supports default non-perception initiative skills from NPCs in the database if the database entry specifies an alternative skill (deception/stealth most common)

All:
- Cleaned up some code with the initiative rolling to make it more streamlined and efficient.