### PR TITLE
Expanding Complex Functionality

### DIFF
--- a/EPF/EPF_Automation_Data.py
+++ b/EPF/EPF_Automation_Data.py
@@ -12,7 +12,7 @@ class Automation_Data(Base):
     # ID Columns
     id = Column(Integer(), primary_key=True, autoincrement=True)
     name = Column(String())
-    display_name = Column(String())
+    display_name = Column(String(), unique=True)
     category = Column(String())
     traits = Column(String())
     level = Column(Integer())

--- a/EPF/EPF_Character.py
+++ b/EPF/EPF_Character.py
@@ -632,6 +632,11 @@ class EPF_Character(Character):
                         self.character_model.bonuses,
                         False,
                     )
+                case "NPC":
+                    if mod:
+                        spmod = spell_data["proficiency"] + self.character_model.level
+                    else:
+                        spmod = spell_data["dc"] - 10 + self.character_model.level
 
                 case _:
                     proficiency = 0

--- a/EPF/EPF_NPC_Importer.py
+++ b/EPF/EPF_NPC_Importer.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import sessionmaker
 
 import EPF.EPF_Character
+from EPF.EPF_Automation_Data import EPF_retreive_complex_data
 from EPF.EPF_Character import get_EPF_Character, delete_intested_items
 from database_models import get_tracker, LookupBase
 from utils.parsing import ParseModifiers
@@ -105,6 +106,20 @@ async def epf_npc_lookup(
         else:
             hp_mod = -30
         stat_mod = -2
+
+    spell_book = {}
+    for spell in data.spells.keys():
+        spell_data = await EPF_retreive_complex_data(spell)
+        if len(spell_data) > 0:
+            for s in spell_data:
+                complex_spell = s.data
+                complex_spell["ability"] = data.spells[spell]["ability"]
+                complex_spell["trad"] = "NPC"
+                complex_spell["dc"] = data.spells[spell]["dc"]
+                complex_spell["proficiency"] = data.spells[spell]["proficiency"]
+                spell_book[s.display_name] = complex_spell
+        else:
+            spell_book[spell] = data.spells[spell]
 
     try:
         async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)


### PR DESCRIPTION
Fixed an error where the Complex lookup data was not enforcing unique name identifies, so the DB was ballooning in size.

Made changes to the EPF NPC import process to use new format spell casting when appropriate. Made corresponding to changes to the EPF_character.get_spell_mod() to accommodate.